### PR TITLE
Update TypeScript textobjects for type definition support

### DIFF
--- a/queries/typescript/textobjects.scm
+++ b/queries/typescript/textobjects.scm
@@ -1,32 +1,25 @@
 ; inherits: ecma
 
-
 ;; interface declaration as class textobject
-(interface_declaration) @class.outer
+(interface_declaration
+  body: (object_type)) @class.outer
 
 (interface_declaration
-  body: _ @class.inner) @class.outer
-
-(interface_declaration
-  body: (object_type . "{" . _ @_start @_end _? @_end . "}"
+  body: (object_type . "{" . (_) @_start @_end _? @_end . "}"
  (#make-range! "class.inner" @_start @_end)))
 
 ;; type alias declaration as class textobject
-(type_alias_declaration) @class.outer
+(type_alias_declaration
+  value: (object_type)) @class.outer
 
 (type_alias_declaration
-  value: _ @class.inner) @class.outer
-
-(type_alias_declaration
-  value: (object_type . "{" . _ @_start @_end _? @_end . "}"
+  value: (object_type . "{" . (_) @_start @_end _? @_end . "}"
  (#make-range! "class.inner" @_start @_end)))
 
-;; enum declaration as class text object
-(enum_declaration) @class.outer
+;; enum declaration as class textobject
+(enum_declaration
+  body: (enum_body)) @class.outer
 
 (enum_declaration
-  body: (enum_body (_) @class.inner)) @class.outer
-
-(enum_declaration
-  body: (enum_body . "{" . _ @_start @_end _? @_end . "}"
+  body: (enum_body . "{" . (_) @_start @_end _? @_end . "}"
  (#make-range! "class.inner" @_start @_end)))

--- a/queries/typescript/textobjects.scm
+++ b/queries/typescript/textobjects.scm
@@ -1,1 +1,32 @@
 ; inherits: ecma
+
+
+;; interface declaration as class textobject
+(interface_declaration) @class.outer
+
+(interface_declaration
+  body: _ @class.inner) @class.outer
+
+(interface_declaration
+  body: (object_type . "{" . _ @_start @_end _? @_end . "}"
+ (#make-range! "class.inner" @_start @_end)))
+
+;; type alias declaration as class textobject
+(type_alias_declaration) @class.outer
+
+(type_alias_declaration
+  value: _ @class.inner) @class.outer
+
+(type_alias_declaration
+  value: (object_type . "{" . _ @_start @_end _? @_end . "}"
+ (#make-range! "class.inner" @_start @_end)))
+
+;; enum declaration as class text object
+(enum_declaration) @class.outer
+
+(enum_declaration
+  body: (enum_body (_) @class.inner)) @class.outer
+
+(enum_declaration
+  body: (enum_body . "{" . _ @_start @_end _? @_end . "}"
+ (#make-range! "class.inner" @_start @_end)))


### PR DESCRIPTION
`interface`, `type` and `enum` declarations are now supported as class `textobject`s.

Known issues:
- the last semicolon (`;`) of the inner text (`interface`, `type`) or the last comma of the inner text (`enum`) are missed.
- an object [declared with `as const`](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums) isn't supported (`value: as_expression` ending with `type_identifier`)

_Related to https://github.com/nvim-treesitter/nvim-treesitter-textobjects/discussions/396_